### PR TITLE
support loading .vgs file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Version 0.02 (beta) - in progress
 - support change volume rate: https://github.com/suzukiplan/vgs-bgm-decoder/issues/3
 - support synthesis mode: https://github.com/suzukiplan/vgs-bgm-decoder/issues/7
+- support loading .vgs file: https://github.com/suzukiplan/vgs-bgm-decoder/issues/8
 - bugfix: https://github.com/suzukiplan/vgs-bgm-decoder/issues/4
 - bugfix: https://github.com/suzukiplan/vgs-bgm-decoder/issues/11
 

--- a/README.md
+++ b/README.md
@@ -3,11 +3,12 @@
 - platform free
 - __UNDER DEVELOPMENT__
 
-## How to use (draft)
+## How to use
 - Create Context
 - Load BGM data (from file or memory)
+  - _Get Meta Information (optional)_
   - Decode
-  - Get/Set Register
+  - _Get/Set Register (optional)_
 - Release Context
 
 ## Create Context
@@ -29,13 +30,28 @@ int vgsdec_load_bgm_from_memory(void* context, void* data, size_t size);
 
 #### arguments
 - `context` : context
-- `path` : path of the BGM file
-- `data` : pointer of memory area that BGM file data stored.
-- `size` : size of the BGM file
+- `path` : path of the .BGM or .vgs file
+- `data` : pointer of memory area that BGM or .vgs file data stored.
+- `size` : size of the .BGM or .vgs file
 
 #### return value
 - `0` : success
 - `-1` : failed
+
+## Get Meta Information
+#### prototyping
+```
+struct VgsMetaHeader* vgsdec_get_meta_header(void* context);
+struct VgsMetaData* vgsdec_get_meta_data(void* context, int index);
+```
+
+#### arguments
+- `context` : context
+- `index` : index of the meta data
+
+#### return value
+- NULL: if meta header or data is not exist.
+- !NULL: meta header or data
 
 ## Decode
 #### prototyping

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,3 +1,4 @@
 test.wav
 test.bgm
+test.vgs
 

--- a/example/decoder.c
+++ b/example/decoder.c
@@ -51,6 +51,8 @@ int main(int argc, char* argv[])
     FILE* wav;
     struct DataHeader dh;
     int i;
+    struct VgsMetaHeader* mhead;
+    struct VgsMetaData* mdata;
 
     if (argc < 3) {
         puts("usage: decoder bgm_file wav_file");
@@ -95,6 +97,32 @@ int main(int argc, char* argv[])
     dh.dsize = 0;
     fwrite(&dh, 1, sizeof(dh), wav);
 
+    /* show meta header if exist */
+    mhead = vgsdec_get_meta_header(context);
+    printf("META-HEADER: ");
+    if (NULL != mhead) {
+        printf("\n");
+        printf(" - format: %s\n", mhead->format);
+        printf(" - genre: %s\n", mhead->genre);
+        printf(" - data count: %d\n", (int)mhead->num);
+    } else {
+        printf("n/a\n");
+    }
+
+    /* show meta data if exist */
+    for (i = 0; NULL != (mdata = vgsdec_get_meta_data(context, i)); i++) {
+        printf("META-DATA #%d:\n", i + 1);
+        printf(" - year: %d\n", (int)mdata->year);
+        printf(" - aid: %d\n", (int)mdata->aid);
+        printf(" - track: %d\n", (int)mdata->track);
+        printf(" - album: %s\n", mdata->album);
+        printf(" - song: %s\n", mdata->song);
+        printf(" - team: %s\n", mdata->team);
+        printf(" - creator: %s\n", mdata->creator);
+        printf(" - right: %s\n", mdata->right);
+        printf(" - code: %s\n", mdata->code);
+    }
+
     /* show length info */
     printf("NUMBER OF NOTES: %d\n", vgsdec_get_value(context, VGSDEC_REG_LENGTH));
     printf("LOOP-INDEX: %d\n", vgsdec_get_value(context, VGSDEC_REG_LOOP_INDEX));
@@ -118,7 +146,7 @@ int main(int argc, char* argv[])
         dh.dsize += sizeof(buf);
     }
 
-    /* wait the end of fadeout if looped */
+    /* waiting for the end of fadeout if looped */
     if (vgsdec_get_value(context, VGSDEC_REG_LOOP_COUNT)) {
         vgsdec_set_value(context, VGSDEC_REG_FADEOUT, 1);
         while (vgsdec_get_value(context, VGSDEC_REG_PLAYING)) {

--- a/example/makefile
+++ b/example/makefile
@@ -7,6 +7,7 @@ decoder: decoder.c ../src/vgs2tone.c ../src/vgsdec.c
 
 test: decoder
 	vgs2mml test.mml test.bgm
-	./decoder test.bgm test.wav
+	vgs2pack test
+	./decoder test.vgs test.wav
 	open test.wav
 

--- a/example/test.meta
+++ b/example/test.meta
@@ -1,0 +1,10 @@
+format = VGS1.0
+genre = Game Music
+
+Data:
+year = 2012
+track = 0
+album = SUZUKI PLAN works
+song = Prelude
+team = SUZUKI PLAN 
+creator = Yoji Suzuki

--- a/src/vgsdec.h
+++ b/src/vgsdec.h
@@ -53,6 +53,32 @@
 extern "C" {
 #endif
 
+struct VgsMetaHeader {
+    char eyecatch[8];
+    char format[8];
+    char genre[32];
+    unsigned char num;
+    unsigned char reserved1[3];
+    unsigned short secIi;
+    unsigned short secIf;
+    unsigned short secLi;
+    unsigned short secLf;
+    unsigned int reserved2;
+};
+
+struct VgsMetaData {
+    unsigned short year;
+    unsigned short aid;
+    unsigned short track;
+    unsigned short reserved;
+    char album[56];
+    char song[64];
+    char team[32];
+    char creator[32];
+    char right[32];
+    char code[32];
+};
+
 void* __stdcall vgsdec_create_context();
 int __stdcall vgsdec_load_bgm_from_file(void* context, const char* path);
 int __stdcall vgsdec_load_bgm_from_memory(void* context, void* data, size_t size);
@@ -60,6 +86,8 @@ void __stdcall vgsdec_execute(void* context, void* buffer, size_t size);
 int __stdcall vgsdec_get_value(void* context, int type);
 void __stdcall vgsdec_set_value(void* context, int type, int value);
 void __stdcall vgsdec_release_context(void* context);
+struct VgsMetaHeader* __stdcall vgsdec_get_meta_header(void* context);
+struct VgsMetaData* __stdcall vgsdec_get_meta_data(void* context, int index);
 
 #ifdef __cplusplus
 };

--- a/src/vgsdec_internal.h
+++ b/src/vgsdec_internal.h
@@ -7,8 +7,10 @@
  */
 #ifdef _WIN32
 #include <windows.h>
+#include <winsock2.h>
 #else
 #include <pthread.h>
+#include <arpa/inet.h>
 #endif
 #include <stdio.h>
 #include <stdlib.h>
@@ -60,6 +62,8 @@ struct _CONTEXT {
     pthread_mutex_t mt;
 #endif
     struct _NOTE notes[MAX_NOTES];
+    struct VgsMetaHeader* mhead;
+    struct VgsMetaData** mdata;
     unsigned char play;
     unsigned char mask;
     unsigned short mvol;
@@ -95,3 +99,5 @@ static void unlock_context(struct _CONTEXT* c);
 static void set_note(struct _CONTEXT* c, unsigned char cn, unsigned char t, unsigned char n);
 static int get_next_note(struct _CONTEXT* c);
 static void jump_time(struct _CONTEXT* c, int sec);
+static size_t extract_meta_data(struct _CONTEXT* c, void* data, size_t size);
+static void release_meta_data(struct _CONTEXT* c);


### PR DESCRIPTION
- `vgsdec_load_bgm_from_file` and `vgsdec_load_bgm_from_memory` are support loading .vgs file
- added read meta header function: `vgsdec_get_meta_header`
- added read meta data function: `vgsdec_get_meta_data`
- described usage of these in the example
- see the https://github.com/suzukiplan/vgs-bgm-decoder/issues/8
